### PR TITLE
On save, check for empty array result

### DIFF
--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -155,7 +155,7 @@ class WP_Post_Meta_Revisioning {
 			$meta_value = get_post_meta( $post_id, $meta_key );
 
 			// Don't save blank meta values
-			if( '' !== $meta_value[0] ) {
+			if( !isset($meta_value[0]) || array_key_exists(0, $meta_value) ||  '' !== $meta_value[0] ) {
 
 				/*
 				 * Use the underlying add_metadata() function vs add_post_meta()


### PR DESCRIPTION
Quiets down some errors upon saving post types which don't use all registered meta keys.