### PR TITLE
Fix PHP notice and ensure array values are always saved

### DIFF
--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -155,7 +155,7 @@ class WP_Post_Meta_Revisioning {
 			$meta_value = get_post_meta( $post_id, $meta_key );
 
 			// Don't save blank meta values
-			if( '' !== $meta_value[0] ) {
+			if ( ! empty( $meta_value ) ) {
 
 				/*
 				 * Use the underlying add_metadata() function vs add_post_meta()


### PR DESCRIPTION
This PR fixes a PHP Notice that would arise if the meta is empty on save, e.g. on the first save of a post: `Notice: Undefined offset: 0 in wp-post-meta-revisions.php on line 158`.

Furthermore, this takes arrays into account. It's hypothetically possible for there to be multiple fields with the same key, where the first field is intentionally left blank. In such a circumstance, the field would be skipped, even though other array indices are populated.