### PR TITLE
Allow for whitelisting/blacklisting keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/adamsilverstein/wp-post-meta-revisions.svg?branch=master)](https://travis-ci.org/adamsilverstein/wp-post-meta-revisions)
 
 === WP-Post-Meta-Revisions ===
-* Contributors: adamsilverstein, mattheu
+* Contributors: adamsilverstein, mattheu, ivankk
 * Requires at least: 4.1
 * Tested up to: 4.5
 * Stable tag: 0.2.2

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post Meta Revisions
  * Plugin URI: https://github.com/adamsilverstein/wp-post-meta-revisions
  * Description: Post Meta Revisions
- * Version: 0.2.2
+ * Version: 0.2.3
  * Author: Adam Silverstein - code developed with others
  * at https://core.trac.wordpress.org/ticket/20564
  * License: GPLv2 or later


### PR DESCRIPTION
Allow for whitelisting / blacklisting of meta keys e.g. blacklisting:

add_filter( 'wp_post_revision_meta_keys', function( $keys ) {
    return array_diff( $keys, array(
        'foo',
        'bar',
        '_edit_last',
		'_edit_lock',
		'_encloseme',
		'_pingme',
)});

This is a breaking change as previously the filter had array() passed to it.

To continue with the whitelisting approach is as simple as:
add_filter( 'wp_post_revision_meta_keys', function( $keys ) {
    return array( 'foo', 'bar' );
)});

Also, now we prevent creating revisions for meta that doesn't exist. Previously, we'd save the result of get_post_meta( $post_id, $meta_key ) which would be the empty string.