### PR TITLE
Refactor how the metadata is inserted

### DIFF
--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -163,7 +163,7 @@ class WP_Post_Meta_Revisioning {
 	 */
 	public function _wp_restore_post_revision_meta( $post_id, $revision_id ) {
 		// Restore revisioned meta fields.
-		$metas_revisioned =  $this->_wp_post_revision_meta_keys();
+		$metas_revisioned = $this->_wp_post_revision_meta_keys();
 		if ( isset( $metas_revisioned ) && 0 !== sizeof( $metas_revisioned ) ) {
 			foreach ( $metas_revisioned as $meta_key ) {
 				// Clear any existing metas

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -134,8 +134,8 @@ class WP_Post_Meta_Revisioning {
 		// Prep the query.
 		global $wpdb;
 		$query = "INSERT INTO $wpdb->postmeta ( post_id, meta_key, meta_value ) VALUES ";
-		$values = [];
-		$place_holders = [];
+		$values = array();
+		$place_holders = array();
 
 		// Save revisioned meta fields.
 		foreach ( $this->_wp_post_revision_meta_keys() as $meta_key ) {

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -152,7 +152,7 @@ class WP_Post_Meta_Revisioning {
 			$query .= implode( ', ', $place_holders );
 
 			// Build and insert the query.
-			$wpdb->query( $wpdb->prepare( "$query ", $values ) );
+			$wpdb->query( $wpdb->prepare( $query, $values ) );
 		}
 	}
 

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -139,20 +139,19 @@ class WP_Post_Meta_Revisioning {
 
 		// Save revisioned meta fields.
 		foreach ( $this->_wp_post_revision_meta_keys() as $meta_key ) {
-			$meta_value = get_post_meta( $post_id, $meta_key );
+			// Serialize the meta data value.
+			$meta_value = serialize( get_post_meta( $post_id, $meta_key ) );
 
-			foreach ( $meta_value as $value ) {
-				array_push( $values, $revision_id, $meta_key, $value );
-				$place_holders[] = '(%d, %s, %s)';
-				continue;
-			}
+			// Push the value into our existing array.
+			array_push( $values, $revision_id, $meta_key, $meta_value );
+			$place_holders[] = '(%d, %s, %s)';
 		}
 
 		// Check to see if the $values aren't empty.
 		if ( ! empty( $values ) ) {
 			$query .= implode( ', ', $place_holders );
 
-			// Build the query.
+			// Build and insert the query.
 			$wpdb->query( $wpdb->prepare( "$query ", $values ) );
 		}
 	}


### PR DESCRIPTION
The current issue is that if you have a lot of meta data i.e: 100 fields that need to be cloned you can experience either the White Screen of Death or a HTTP 504 error because we are doing 100 INSERT queries at once. This solution should take care this issue.

- [x] Fix existing Unit Test issues
- [x] Code review