### PR TITLE
#32 - Add check for empty value

### DIFF
--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -134,6 +134,10 @@ class WP_Post_Meta_Revisioning {
 		foreach ( $this->_wp_post_revision_meta_keys() as $meta_key ) {
 			$meta_value = get_post_meta( $post_id, $meta_key );
 
+			if ( empty( $meta_value ) ) {
+				continue 1;
+			}
+
 			/*
 			 * Use the underlying add_metadata() function vs add_post_meta()
 			 * to ensure metadata is added to the revision post and not its parent.


### PR DESCRIPTION
#32 - Prevent the creation of empty meta keys that didn't exist on the copied post, but exist in the whitelist, this wont stop an empty key from being copied.