### PR TITLE
Docs: various comment format fixes

### DIFF
--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -90,11 +90,11 @@ class MetaRevisionTests extends WP_UnitTestCase {
 
 	/**
 	 * Test the revisions system for storage of meta values
+	 *
 	 * @group revision
 	 */
 	public function test_revisions_stores_meta_values() {
-
-		/**
+		/*
 		 * Set Up.
 		 */
 
@@ -114,7 +114,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$revisions = wp_get_post_revisions( $post_id );
 		$this->assertCount( 1, $revisions );
 
-		/**
+		/*
 		 * First set up a meta value
 		 */
 
@@ -146,7 +146,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$revisions = wp_get_post_revisions( $post_id );
 		$this->assertCount( 3, $revisions );
 
-		/**
+		/*
 		 * Now restore the original revision
 		 */
 
@@ -164,7 +164,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$revisions = wp_get_post_revisions( $post_id );
 		$this->assertCount( 4, $revisions );
 
-		/**
+		/*
 		 * Check the meta values to verify they are NOT revisioned - they are not revisioned by default.
 		 */
 
@@ -194,12 +194,11 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		// Store custom meta values, which should now be revisioned
 		update_post_meta( $post_id, 'meta_revision_test', 'update3' );
 
-		/**
+		/*
 		 * Save the post again, custom meta should now be revisioned
 		 *
 		 * Note that a revision is saved even though there is no change
 		 * in post content, because the revisioned post_meta has changed
-		 *
 		 */
 		wp_update_post(
 			array(
@@ -222,7 +221,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
-		/**
+		/*
 		 * Verify that previous post meta is restored.
 		 */
 		$this->assertEquals( 'update2', get_post_meta( $post_id, 'meta_revision_test', true ) );
@@ -248,7 +247,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
-		/**
+		/*
 		 * Verify that previous blank post meta is restored
 		 */
 		$this->assertEquals( '', get_post_meta( $post_id, 'meta_revision_test', true ) );
@@ -280,7 +279,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
-		/**
+		/*
 		 * Verify that previous post meta is NOT restored.
 		 */
 		$this->assertEquals( 'update 6', get_post_meta( $post_id, 'meta_revision_test', true ) );
@@ -288,7 +287,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		// Add the custom field to be revised via the wp_post_revision_meta_keys filter
 		add_filter( 'wp_post_revision_meta_keys', array( $this, 'add_revisioned_keys' ) );
 
-		/**
+		/*
 		 * Test the revisioning of multiple meta keys
 		 */
 
@@ -310,12 +309,12 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
-		/**
+		/*
 		 * Verify that multiple metas stored correctly.
 		 */
 		$this->assertEquals( array( 'update 7', 'update 7 number 2', 'update 7 number 3' ), get_post_meta( $post_id, 'meta_revision_test' ) );
 
-		/**
+		/*
 		 * Test the revisioning of a multidimensional array.
 		 */
 		$test_array = array(
@@ -356,7 +355,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
-		/**
+		/*
 		 * Verify  multidimensional array stored correctly.
 		 */
 		$stored_array = get_post_meta( $post_id, 'meta_revision_test' );

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Plugin Name: Post Meta Revisions
  * Plugin URI: https://github.com/adamsilverstein/wp-post-meta-revisions
  * Description: Post Meta Revisions
@@ -7,7 +7,7 @@
  * Author: Adam Silverstein - code developed with others
  * at https://core.trac.wordpress.org/ticket/20564
  * License: GPLv2 or later
-*/
+ */
 
 class WP_Post_Meta_Revisioning {
 
@@ -54,14 +54,13 @@ class WP_Post_Meta_Revisioning {
 	 * @param Post object $new_autosave The new post being autosaved.
 	 */
 	public function _wp_autosave_post_revisioned_meta_fields( $new_autosave ) {
-
-		/**
+		/*
 		 * The post data arrives as either $_POST['data']['wp_autosave'] or the $_POST
 		 * itself. This sets $posted_data to the correct variable.
 		 */
 		$posted_data = isset( $_POST['data'] ) ? $_POST['data']['wp_autosave'] : $_POST; // WPCS: CSRF ok. input var ok. sanitization ok.
 
-		/**
+		/*
 		 * Go thru the revisioned meta keys and save them as part of the autosave, if
 		 * the meta key is part of the posted data, the meta value is not blank and
 		 * the the meta value has changes from the last autosaved value.
@@ -72,7 +71,6 @@ class WP_Post_Meta_Revisioning {
 				isset( $posted_data[ $meta_key ] ) &&
 				get_post_meta( $new_autosave['ID'], $meta_key, true ) !== wp_unslash( $posted_data[ $meta_key ] )
 			) {
-
 				/*
 				 * Use the underlying delete_metadata() and add_metadata() functions
 				 * vs delete_post_meta() and add_post_meta() to make sure we're working
@@ -80,12 +78,11 @@ class WP_Post_Meta_Revisioning {
 				 */
 				delete_metadata( 'post', $new_autosave['ID'], $meta_key );
 
-				/**
+				/*
 				 * One last check to ensure meta value not empty().
 				 */
 				if ( ! empty( $posted_data[ $meta_key ] ) ) {
-
-					/**
+					/*
 					 * Add the revisions meta data to the autosave.
 					 */
 					add_metadata( 'post', $new_autosave['ID'], $meta_key, $posted_data[ $meta_key ] );


### PR DESCRIPTION
1. Use block comments for inline comments.
    A docblock `/** ... */` is a special type of comment which should only be used to document structural elements, such as files, classes, properties, methods, hooks etc.

    For inline comments, either the single line `//` or the multi-line `/* ... */` block comment style should be used.

2. Use docblocks for structural elements (main plugin file, file docblock).

3. There should always be a blank line before the first tag in a docblock.

4. There should not be superfluous blank lines in docblocks or multi-line comments, so no blank comment line at the end and no multiple blank lines.

5. No blank line required above block comments when it's the first thing in a function or conditional.