### PR TITLE
Only revision existing metadata

### DIFF
--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -13,11 +13,29 @@
 class MetaRevisionTests extends WP_UnitTestCase {
 
 	/**
+	 * @var array
+	 */
+	protected $revisioned_keys;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	function setUp() {
+		parent::setUp();
+
+		// Reset for current test
+		$this->revisioned_keys = array( 'meta_revision_test' );
+	}
+
+	/**
 	 * Callback function to add the revisioned keys
+	 *
+	 * @param array $keys
+	 *
+	 * @return array
 	 */
 	public function add_revisioned_keys( $keys ) {
-		$keys[] = 'meta_revision_test';
-		return $keys;
+		return array_unique( array_merge( $keys, $this->revisioned_keys ) );
 	}
 
 	/**

--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -394,4 +394,12 @@ class MetaRevisionTests extends WP_UnitTestCase {
 
 	}
 
+	protected function assertPostHasMetaKey( $post_id, $meta_key ) {
+		$this->assertArrayHasKey( $meta_key, get_metadata( 'post', $post_id ) );
+	}
+
+	protected function assertPostNotHasMetaKey( $post_id, $meta_key ) {
+		$this->assertArrayNotHasKey( $meta_key, get_metadata( 'post', $post_id ) );
+	}
+
 }

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -146,13 +146,15 @@ class WP_Post_Meta_Revisioning {
 
 		// Save revisioned meta fields.
 		foreach ( $this->_wp_post_revision_meta_keys() as $meta_key ) {
-			$meta_value = get_post_meta( $post_id, $meta_key );
+			if ( metadata_exists( 'post', $post_id, $meta_key ) ) {
+				$meta_value = get_post_meta( $post_id, $meta_key );
 
-			/*
-			 * Use the underlying add_metadata() function vs add_post_meta()
-			 * to ensure metadata is added to the revision post and not its parent.
-			 */
-			add_metadata( 'post', $revision_id, $meta_key, wp_slash( $meta_value ) );
+				/*
+				 * Use the underlying add_metadata() function vs add_post_meta()
+				 * to ensure metadata is added to the revision post and not its parent.
+				 */
+				add_metadata( 'post', $revision_id, $meta_key, wp_slash( $meta_value ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates the logic for meta which is created on the revision.

Currently, a post meta entry is created for every revisioned meta key, whether it exists or not.

This adds a simple check to see if the meta exists first and only creates an entry on the revision if it does.

---

Also included are updates to the test case to cover this change as well as a few enhancements to the test case itself:
- Adds the ability to more easily control which revisioned meta keys to use on a per-test basis
- Adds a few assertion helper methods for checking if a post has a particular meta key or not 

Resolves #32 