### PR TITLE
Update revision meta storage format for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/adamsilverstein/wp-post-meta-revisions.svg?branch=master)](https://travis-ci.org/adamsilverstein/wp-post-meta-revisions)
 
 === WP-Post-Meta-Revisions ===
-* Contributors: adamsilverstein, mattheu
+* Contributors: adamsilverstein, mattheu, aaemnnosttv
 * Requires at least: 4.1
 * Tested up to: 4.9
 * Stable tag: 1.0.0
@@ -13,7 +13,7 @@ Allow selected post meta keys to be tracked in revisions.
 == Description ==
 
 ## Important
-**Version 2.0.0** of this plugin introduces a streamlined storage format for revisioned meta that is not backwards compatible with previous versions (1.0 and lower) of the plugin. Restoring revisions data from a previous version is not supported and arrays may not work as expected. If you need to be able to restore from previous versions, avoid upgrading or read the full issue to see how you can migrate your data: https://github.com/adamsilverstein/wp-post-meta-revisions/pull/56/.
+**Version 2.0.0** of this plugin introduces a streamlined storage format for revisioned meta that is not completely backwards compatible with previous versions of the plugin. Restoring revisions data from a previous version where array data was stored may not work as expected. If you need to be able to restore array data revisioned in previous versions, avoid upgrading or read the full issue to see how your data may be impacted: https://github.com/adamsilverstein/wp-post-meta-revisions/pull/56/.
 
 This plugin implements a <i>post meta revisioning</i> feature as arrived at in https://core.trac.wordpress.org/ticket/20564.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Allow selected post meta keys to be tracked in revisions.
 
 == Description ==
 
+## Important
+**Version 2.0.0** of this plugin introduces a streamlined storage format for revisioned meta that is not backwards compatible with previous versions (1.0 and lower) of the plugin. Restoring revisions data from a previous version is not supported and arrays may not work as expected. If you need to be able to restore from previous versions, avoid upgrading or read the full issue to see how you can migrate your data: https://github.com/adamsilverstein/wp-post-meta-revisions/pull/56/.
+
 This plugin implements a <i>post meta revisioning</i> feature as arrived at in https://core.trac.wordpress.org/ticket/20564.
 
 The goal of releasing this code as a plugin is to allow as many people as possible to easily test the post meta revisioning feature, and also hopefully move towards inclusion of the feature into core, following the <a href="https://make.wordpress.org/core/features-as-plugins/">Features as Plugins</a> model.

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,10 @@ Features:
 
 == Changelog ==
 
+= 2.0.0 =
+* Post meta storage mechanism simplified to use copy approach. This change updates the way meta is stored on the revision to mirror the meta on the post it is created from. props @aaemnnosttv, see https://github.com/adamsilverstein/wp-post-meta-revisions/pull/56.
+NOTE: This is a breaking change - restoring revisions saved in the previous format may result in an array of values restored as a single value rather than adding a value for each item in the array
+
 = 1.0.0 =
 Tagging release as 1.0.
 

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ Features:
 
 = 2.0.0 =
 * Post meta storage mechanism simplified to use copy approach. This change updates the way meta is stored on the revision to mirror the meta on the post it is created from. props @aaemnnosttv, see https://github.com/adamsilverstein/wp-post-meta-revisions/pull/56.
-NOTE: This is a breaking change - restoring revisions saved in the previous format may result in an array of values restored as a single value rather than adding a value for each item in the array
+NOTE: This is a breaking change - restoring revisions saved in the previous format may result in the array of values restored as a single value rather than adding a value for each item in the array. The storage of single meta values is unaffected.
 
 = 1.0.0 =
 Tagging release as 1.0.

--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -325,7 +325,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		update_post_meta( $post_id, 'meta_revision_test', 'update 8 number 3', 'update 7 number 3' );
 
 		// Restore the previous revision.
-		$revisions = wp_get_post_revisions( $post_id );
+		$revisions     = wp_get_post_revisions( $post_id );
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
@@ -367,7 +367,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		update_post_meta( $post_id, 'meta_revision_test', '' );
 
 		// Restore the previous revision.
-		$revisions = wp_get_post_revisions( $post_id );
+		$revisions     = wp_get_post_revisions( $post_id );
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
@@ -390,17 +390,17 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		wp_update_post( array( 'ID' => $post_id ) );
 
 		$stored_array = get_post_meta( $post_id, 'meta_multiples_test' );
-		$expect = array( 'test1', 'test2', 'test3' );
+		$expect       = array( 'test1', 'test2', 'test3' );
 
- 		$this->assertEquals( $expect, $stored_array );
+		$this->assertEquals( $expect, $stored_array );
 
 		// Restore the previous revision.
-		$revisions = wp_get_post_revisions( $post_id );
- 		$last_revision = array_shift( $revisions );
+		$revisions     = wp_get_post_revisions( $post_id );
+		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
 		$stored_array = get_post_meta( $post_id, 'meta_multiples_test' );
-		$expect = array( 'test1', 'test2', 'test3' );
+		$expect       = array( 'test1', 'test2', 'test3' );
 
 		$this->assertEquals( $expect, $stored_array );
 

--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -21,6 +21,7 @@ class MetaRevisionTests extends WP_UnitTestCase {
 	 */
 	public function add_revisioned_keys( $keys ) {
 		$keys[] = 'meta_revision_test';
+		$keys[] = 'meta_multiples_test';
 		return $keys;
 	}
 
@@ -322,11 +323,9 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		update_post_meta( $post_id, 'meta_revision_test', 'update 8', 'update 7' );
 		update_post_meta( $post_id, 'meta_revision_test', 'update 8 number 2', 'update 7 number 2' );
 		update_post_meta( $post_id, 'meta_revision_test', 'update 8 number 3', 'update 7 number 3' );
-		wp_update_post( array( 'ID' => $post_id ) );
 
 		// Restore the previous revision.
 		$revisions = wp_get_post_revisions( $post_id );
-		array_shift( $revisions );
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
@@ -367,12 +366,8 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		// Set the test meta blank.
 		update_post_meta( $post_id, 'meta_revision_test', '' );
 
-		// Update to save.
-		wp_update_post( array( 'ID' => $post_id ) );
-
 		// Restore the previous revision.
 		$revisions = wp_get_post_revisions( $post_id );
-		array_shift( $revisions );
 		$last_revision = array_shift( $revisions );
 		wp_restore_post_revision( $last_revision->ID );
 
@@ -382,9 +377,34 @@ class MetaRevisionTests extends WP_UnitTestCase {
 		$stored_array = get_post_meta( $post_id, 'meta_revision_test' );
 		$this->assertEquals( $test_array, $stored_array[0] );
 
+		/*
+		 * Test multiple revisions on the same key.
+		 */
+
+		// Set the test meta to the array.
+		add_post_meta( $post_id, 'meta_multiples_test', 'test1' );
+		add_post_meta( $post_id, 'meta_multiples_test', 'test2' );
+		add_post_meta( $post_id, 'meta_multiples_test', 'test3' );
+
+		// Update to save.
+		wp_update_post( array( 'ID' => $post_id ) );
+
+		$stored_array = get_post_meta( $post_id, 'meta_multiples_test' );
+		$expect = array( 'test1', 'test2', 'test3' );
+
+ 		$this->assertEquals( $expect, $stored_array );
+
+		// Restore the previous revision.
+		$revisions = wp_get_post_revisions( $post_id );
+ 		$last_revision = array_shift( $revisions );
+		wp_restore_post_revision( $last_revision->ID );
+
+		$stored_array = get_post_meta( $post_id, 'meta_multiples_test' );
+		$expect = array( 'test1', 'test2', 'test3' );
+
+		$this->assertEquals( $expect, $stored_array );
+
 		// Cleanup!
 		wp_delete_post( $original_post_id );
-
 	}
-
 }

--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -198,8 +198,9 @@ class MetaRevisionTests extends WP_UnitTestCase {
 			)
 		);
 
-		$revisions = wp_get_post_revisions( $post_id );
+		$revisions = array_values( wp_get_post_revisions( $post_id ) );
 		$this->assertCount( 5, $revisions );
+		$this->assertEquals( 'update2', get_post_meta( $revisions[0]->ID, 'meta_revision_test', true ) );
 
 		// Store custom meta values, which should now be revisioned
 		update_post_meta( $post_id, 'meta_revision_test', 'update3' );

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -173,7 +173,7 @@ class WP_Post_Meta_Revisioning {
 	public function wp_restore_post_revision_meta( $post_id, $revision_id ) {
 
 		// Restore revisioned meta fields.
-		foreach ( (array) $this->_wp_post_revision_meta_keys() as $meta_key ) {
+		foreach ( (array) $this->wp_post_revision_meta_keys() as $meta_key ) {
 
 			// Clear any existing meta.
 			delete_post_meta( $post_id, $meta_key );

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -47,7 +47,7 @@ class WP_Post_Meta_Revisioning {
 	/**
 	 * Add the revisioned meta to get_post_metadata for preview meta data.
 	 *
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 */
 	public function add_metadata_preview_filter() {
 		add_filter( 'get_post_metadata', array( $this, 'wp_preview_meta_filter' ), 10, 4 );
@@ -59,7 +59,7 @@ class WP_Post_Meta_Revisioning {
 	 * Iterates thru the revisioned meta fields and checks each to see if they are set,
 	 * and have a changed value. If so, the meta value is saved and attached to the autosave.
 	 *
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 *
 	 * @param Post object $new_autosave The new post being autosaved.
 	 */
@@ -111,7 +111,7 @@ class WP_Post_Meta_Revisioning {
 	 * Determine which post meta fields should be revisioned.
 	 *
 	 * @access public
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 *
 	 * @return array An array of meta keys to be revisioned.
 	 */
@@ -119,7 +119,7 @@ class WP_Post_Meta_Revisioning {
 		/**
 		 * Filter the list of post meta keys to be revisioned.
 		 *
-		 * @since 4.5.0
+		 * @since 1.0.0
 		 *
 		 * @param array $keys An array of default meta fields to be revisioned.
 		 */
@@ -133,7 +133,7 @@ class WP_Post_Meta_Revisioning {
 	 * @param WP_Post $last_revision    The last revision post object.
 	 * @param WP_Post $post             The post object.
 	 *
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 */
 	public function wp_check_revisioned_meta_fields_have_changed( $post_has_changed, WP_Post $last_revision, WP_Post $post ) {
 		foreach ( $this->wp_post_revision_meta_keys() as $meta_key ) {
@@ -150,7 +150,7 @@ class WP_Post_Meta_Revisioning {
 	 *
 	 * @param int $revision_id The ID of the revision to save the meta to.
 	 *
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 */
 	public function wp_save_revisioned_meta_fields( $revision_id ) {
 		$revision = get_post( $revision_id );
@@ -168,7 +168,7 @@ class WP_Post_Meta_Revisioning {
 	 * @param int $post_id     The ID of the post to restore the meta to.
 	 * @param int $revision_id The ID of the revision to restore the meta from.
 	 *
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 */
 	public function wp_restore_post_revision_meta( $post_id, $revision_id ) {
 
@@ -188,6 +188,8 @@ class WP_Post_Meta_Revisioning {
 	 * @param int    $source_post_id Post ID to copy meta value(s) from.
 	 * @param int    $target_post_id Post ID to copy meta value(s) to.
 	 * @param string $meta_key       Meta key to copy.
+	 *
+	 * @since 2.0.0
 	 */
 	protected function copy_post_meta( $source_post_id, $target_post_id, $meta_key ) {
 		foreach ( get_post_meta( $source_post_id, $meta_key ) as $meta_value ) {
@@ -206,7 +208,7 @@ class WP_Post_Meta_Revisioning {
 	 * Filters revisioned meta keys only.
 	 *
 	 * @access public
-	 * @since 4.5.0
+	 * @since 1.0.0
 	 *
 	 * @param mixed  $value     Meta value to filter.
 	 * @param int    $object_id Object ID.

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -171,11 +171,11 @@ class WP_Post_Meta_Revisioning {
 	 * @since 4.5.0
 	 */
 	public function wp_restore_post_revision_meta( $post_id, $revision_id ) {
+
 		// Restore revisioned meta fields.
-		$metas_revisioned = $this->wp_post_revision_meta_keys();
-		if ( isset( $metas_revisioned ) && 0 !== count( $metas_revisioned ) ) {
 		foreach ( (array) $this->_wp_post_revision_meta_keys() as $meta_key ) {
-			// Clear any existing metas
+
+			// Clear any existing meta.
 			delete_post_meta( $post_id, $meta_key );
 
 			$this->copy_post_meta( $revision_id, $post_id, $meta_key );

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -10,7 +10,7 @@
  * Plugin Name: Post Meta Revisions
  * Plugin URI: https://github.com/adamsilverstein/wp-post-meta-revisions
  * Description: Post Meta Revisions
- * Version: 1.0.0
+ * Version: 2.0.0
  * Author: Adam Silverstein - code developed with others
  * at https://core.trac.wordpress.org/ticket/20564
  * License: GPLv2 or later
@@ -192,6 +192,7 @@ class WP_Post_Meta_Revisioning {
 	 * @since 2.0.0
 	 */
 	protected function copy_post_meta( $source_post_id, $target_post_id, $meta_key ) {
+
 		foreach ( get_post_meta( $source_post_id, $meta_key ) as $meta_value ) {
 			/**
 			 * We use add_metadata() function vs add_post_meta() here

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -185,9 +185,9 @@ class WP_Post_Meta_Revisioning {
 	/**
 	 * Copy post meta for the given key from one post to another.
 	 *
-	 * @param int $source_post_id Post ID to copy meta value(s) from
-	 * @param int $target_post_id Post ID to copy meta value(s) to
-	 * @param string $meta_key    Meta key to copy
+	 * @param int    $source_post_id Post ID to copy meta value(s) from.
+	 * @param int    $target_post_id Post ID to copy meta value(s) to.
+	 * @param string $meta_key       Meta key to copy.
 	 */
 	protected function copy_post_meta( $source_post_id, $target_post_id, $meta_key ) {
 		foreach ( get_post_meta( $source_post_id, $meta_key ) as $meta_value ) {


### PR DESCRIPTION
This PR fixes the way post meta is saved on the revision. Currently post meta values are saved as an array of values under a single meta key, instead of multiple meta values (rows). This change updates the way meta is stored on the revision to mirror the meta on the post it is created from.

As is, this is a breaking change as existing meta values are all saved under a single key, so restoring to a revision that uses meta saved in the old format would restore the array of values as a single value rather than adding a value for each item in the array. I'm not sure there is a good way around this, without adding some additional level of versioning to the revisioned meta since an array is a valid single meta value. Alternatively, there could be a database upgrade routine that would update from the old single array value to the proposed format which is consistent with how it is stored on the source post.

This PR also introduces a new method to reduce the duplication for copying meta from one post to another which is used when revisioning and restoring.

Resolves #13 