### PR TITLE
Support non-unique meta key in autosave

### DIFF
--- a/tests/test-meta-revisions.php
+++ b/tests/test-meta-revisions.php
@@ -404,6 +404,48 @@ class MetaRevisionTests extends WP_UnitTestCase {
 
 		$this->assertEquals( $expect, $stored_array );
 
+		/*
+		 * Test autosave saving single/unique metadata.
+		 */
+
+		$_POST = array(
+			'meta_revision_test' => 'autosave',
+		);
+		wp_create_post_autosave(
+			array(
+				'post_content' => 'Autosave content.',
+				'post_ID'      => $post_id,
+				'post_type'    => 'post',
+			)
+		);
+		$autosave_post = wp_get_post_autosave( $post_id );
+		$this->assertEquals( 'autosave', get_post_meta( $autosave_post->ID, 'meta_revision_test', true ) );
+
+		/*
+		 * Test autosave saving multiple/non-unique metadata.
+		 */
+
+		// Register `meta_revision_test` as non-unique meta key.
+		register_post_meta( '', 'meta_revision_test', [ 'single' => false ] );
+
+		$_POST = array(
+			'meta_multiples_test' => array(
+				'autosave',
+				'autosave2',
+				'autosave3',
+			)
+		);
+		wp_create_post_autosave(
+			array(
+				'post_content' => 'Autosave content.',
+				'post_ID'      => $post_id,
+				'post_type'    => 'post',
+			)
+		);
+		$autosave_post = wp_get_post_autosave( $post_id );
+		$this->assertEquals( array( 'autosave', 'autosave2', 'autosave3' ), get_post_meta( $autosave_post->ID, 'meta_revision_test', false ) );
+
+
 		// Cleanup!
 		wp_delete_post( $original_post_id );
 	}


### PR DESCRIPTION
### Problem
https://github.com/adamsilverstein/wp-post-meta-revisions/issues/60

### Solution
Pete mention in https://github.com/adamsilverstein/wp-post-meta-revisions/issues/24 that a filter to modify the metadata from the `$_POST` variable.

I look at the PR https://github.com/adamsilverstein/wp-post-meta-revisions/pull/25 but soon realised this would not be a solution for this problem as `add_metadata()` needs to called multiple times for each non-unique meta data.

In addition there is a check if the data has been changed. `get_post_meta()` is setup to get only a single value, the first value which does not work for non-unique meta values.
https://github.com/adamsilverstein/wp-post-meta-revisions/blob/ca459926808b025c256654962e577c91597dd0e0/wp-post-meta-revisions.php#L88

In [WP 4.9.8](https://make.wordpress.org/core/2018/07/27/registering-metadata-in-4-9-8/) `register_post_meta()` was introduced. This allows developers to register meta key as non-unique and allows us to use the data to save the data correctly.  This is how I have done it in the test:
```php
register_post_meta( '', 'meta_revision_test', [ 'single' => false ] );
```

I have added tests for autosaving both unique and non-unique meta data.